### PR TITLE
Resolving issue #194

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,0 +1,20 @@
+- title: Meetup
+  description: The Stockholm AI meetups aims to bring together a broader audience of AI professionals, startups, investors and academia in the AI sphere together to understand the current state of the technology and what is in store for the near future.
+
+- title: Study Group
+  description: The purpose of the Stockholm AI study groups is to go into depth on research articles, concepts, blog post, and master’s theses. This to advance professional practitioners of AI and machine learning to increase their practical and theoretical skills.
+
+- title: Mentorship
+  description: Stockholm AI arranges a mentorship program for all Stockholm AI members. Mentees who want to learn things related to AI, for example deep learning, business aspects of AI, random forest or ethical aspects within AI, are matched with appropriate and experienced mentors. Are you interested in mentoring or being mentored?
+
+- title: Job Board
+  description: Stockholm AI job board gathers all the relevant job within AI in Stockholm, which is broadcasted to all of our members.
+
+- title: Academic Reading Group
+  description: Takes place at KTH every 2-3 weeks. The academic reading group meets to discuss scientific ML/AI papers to broaden the understanding of the underlying theory and learn about new methods.
+
+- title: Weekly Hack
+  description: The weekly AI hacks serves as an relaxed open forum where AI enthusiasts gathers to get help with, work on, and discuss AI related projects. Bring a laptop, research paper or just your ideas and have a nice cup of coffee with the Stockholm AI community.
+
+- title: Distilling AI
+  description: Distilling AI is a study group where we digest different AI-related concepts to arrive at intuitive abstractions and visualizations. Every series of topics is distilled by smaller intimate groups during a few sessions and later shared with the community.

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,20 +1,27 @@
 - title: Meetup
   description: The Stockholm AI meetups aims to bring together a broader audience of AI professionals, startups, investors and academia in the AI sphere together to understand the current state of the technology and what is in store for the near future.
+  favicon: fa-meetup
 
 - title: Study Group
   description: The purpose of the Stockholm AI study groups is to go into depth on research articles, concepts, blog post, and master’s theses. This to advance professional practitioners of AI and machine learning to increase their practical and theoretical skills.
+  favicon: fa-book
 
 - title: Mentorship
   description: Stockholm AI arranges a mentorship program for all Stockholm AI members. Mentees who want to learn things related to AI, for example deep learning, business aspects of AI, random forest or ethical aspects within AI, are matched with appropriate and experienced mentors. Are you interested in mentoring or being mentored?
+  favicon: fa-user
 
 - title: Job Board
   description: Stockholm AI job board gathers all the relevant job within AI in Stockholm, which is broadcasted to all of our members.
+  favicon: fa-briefcase
 
 - title: Academic Reading Group
   description: Takes place at KTH every 2-3 weeks. The academic reading group meets to discuss scientific ML/AI papers to broaden the understanding of the underlying theory and learn about new methods.
+  favicon: fa-book
 
 - title: Weekly Hack
   description: The weekly AI hacks serves as an relaxed open forum where AI enthusiasts gathers to get help with, work on, and discuss AI related projects. Bring a laptop, research paper or just your ideas and have a nice cup of coffee with the Stockholm AI community.
+  favicon: fa-laptop
 
 - title: Distilling AI
   description: Distilling AI is a study group where we digest different AI-related concepts to arrive at intuitive abstractions and visualizations. Every series of topics is distilled by smaller intimate groups during a few sessions and later shared with the community.
+  favicon: fa-laptop

--- a/_includes/what_we_do.html
+++ b/_includes/what_we_do.html
@@ -21,7 +21,7 @@
                 <div class="col-md-4">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-meetup fa-stack-1x fa-inverse"></i>
+                        <i class="fa {{ service.favicon }} fa-stack-1x fa-inverse"></i>
                     </span>
                     <h4 class="service-heading">{{ service.title }}</h4>
                     <p class="text-muted">

--- a/_includes/what_we_do.html
+++ b/_includes/what_we_do.html
@@ -17,14 +17,15 @@
             </div>
 
             <div class="row text-justify">
+                {% for service in site.data.services %}
                 <div class="col-md-4">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-meetup fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Meetup</h4>
+                    <h4 class="service-heading">{{ service.title }}</h4>
                     <p class="text-muted">
-                        The {{ site.data.organization.name }} meetups aims to bring together a broader audience of AI professionals, startups, investors and academia in the AI sphere together to understand the current state of the technology and what is in store for the near future.
+                    {{ service.description }}
                     </p>
                     <br>
 
@@ -33,99 +34,7 @@
                     <br /><br /><br /><br />
 
                 </div>
-
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-book fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Study Group</h4>
-                    <p class="text-muted">
-                        The purpose of the {{ site.data.organization.name }} study groups is to go into depth on research articles, concepts, blog post, and master’s theses.
-                        This to advance professional practitioners of AI and machine learning to increase their practical and theoretical skills.
-                    </p>
-                    <br>
-
-                    <a href="/study-groups" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
-
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-user fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Mentorship</h4>
-                    <p class="text-muted">
-                        Stockholm AI arranges a mentorship program for all Stockholm AI members. Mentees who want to learn things related to AI, for example deep learning, business aspects of AI, random forest or ethical aspects within AI, are matched with appropriate and experienced mentors. Are you interested in mentoring or being mentored?
-                    </p>
-                    <a href="/mentorship" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
- 
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-briefcase fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Job Board</h4>
-                    <p class="text-muted">
-                        Stockholm AI job board gathers all the relevant job within AI in Stockholm, which is broadcasted to all of our members.
-                    </p>
-                    <a href="/jobs" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
-
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-book fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Academic Reading Group</h4>
-                    <p class="text-muted">
-                        Takes place at KTH every 2-3 weeks. The academic reading group meets to discuss scientific ML/AI papers to broaden the understanding of the underlying theory and learn about new methods.
-                    </p>
-                    <a href="https://www.facebook.com/groups/stockholmai" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
-
-               <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-laptop fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Weekly Hack</h4>
-                    <p class="text-muted">
-                        The weekly AI hacks serves as an relaxed open forum where AI enthusiasts gathers to get help with, work on, and discuss AI related projects. Bring a laptop, research paper or just your ideas and have a nice cup of coffee with the Stockholm AI community.
-                    </p>
-                    <a href="https://www.facebook.com/groups/stockholmai" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
-
-		<div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-laptop fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Distilling AI</h4>
-                    <p class="text-muted">
-                        Distilling AI is a study group where we digest different AI-related concepts to arrive at intuitive abstractions and visualizations. Every series of topics is distilled by smaller intimate groups during a few sessions and later shared with the community.
-                    </p>
-                    <a href="https://www.facebook.com/groups/stockholmai" class="page-scroll btn btn-xl">Read More</a>
-
-                    <br /><br /><br /><br />
-
-                </div>
+                {% endfor %}
 
             </div>
 


### PR DESCRIPTION
- the services.yml stores the data of "what_we_do" projects
- substituted all `{{ data.organisation.name }}` in the service
description because they do not seem to translate to "Stockholm AI"